### PR TITLE
Frontend + config changes for ruff auto-fixing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
+        args: [--fix]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -1,0 +1,28 @@
+import sqlite3
+
+import pandas as pd
+import streamlit as st
+
+st.set_page_config(page_title="Hospital bed management", page_icon="🏥")
+
+st.title("Bed Assignments")
+
+conn = sqlite3.connect("./db/hospital.db")
+
+query = """
+SELECT
+    bed_assignments.bed_id,
+    bed_assignments.patient_id,
+    CONCAT(patients.first_name, ' ', patients.last_name) AS patient_name,
+    patients.sickness,
+    bed_assignments.days_of_stay
+FROM bed_assignments
+JOIN patients ON bed_assignments.patient_id = patients.patient_id;
+"""
+df = pd.read_sql_query(query, conn)
+conn.close()
+
+if not df.empty:
+    st.dataframe(df, use_container_width=True)
+else:
+    st.info("No bed assignments found.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pydantic==2.11.4
 Faker==37.1.0
+
+streamlit==1.41.1
+pandas==2.2.3


### PR DESCRIPTION
This pull request introduces a new Streamlit-based frontend to display hospital bed assignments and updates the pre-commit configuration to automatically fix linting issues using `ruff`. Below are the key changes:

### Frontend Implementation:

* [`frontend/main.py`](diffhunk://#diff-b2ca51a84b7adeb7627daf85a4c732b27747ce91e275196ab182a323e7842a72R1-R28): Added a new Streamlit application to display bed assignments from a SQLite database. The app connects to the database, retrieves bed assignment data using a SQL query, and displays it in a table format using Streamlit's `st.dataframe`. If no data is available, an informational message is shown.

### Pre-commit Configuration:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R9): Updated the `ruff` linter configuration to include the `--fix` argument, enabling automatic fixing of linting issues during pre-commit checks.