### PR TITLE
Stopping frontend while call

### DIFF
--- a/frontend/main.py
+++ b/frontend/main.py
@@ -293,7 +293,10 @@ else:
 
 st.sidebar.subheader(f"Auto: {st.session_state.auto_day_change}, Button press: {st.session_state.button_pressed}")
 st.sidebar.toggle(
-    label="Activate automatic day change", value=st.session_state.auto_day_change, on_change=toggle_auto_day_change
+    label="Activate automatic day change",
+    value=st.session_state.auto_day_change,
+    key="auto_day_change",
+    on_change=toggle_auto_day_change,
 )
 
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -269,6 +269,7 @@ main_tab.header(f"Day {st.session_state.day_for_simulation}")
 
 if len(bed_df[bed_df["patient_id"] == 0]) > 0 and len(queue_df) > 0:
     st.session_state.consent = False
+    st.session_state.auto_day_change = False
     st.sidebar.button("Call next patient in queue 📞", on_click=lambda: agent_call(queue_df))
 elif st.session_state.day_for_simulation < 20 and st.session_state.auto_day_change:
     st_autorefresh(interval=10000, limit=None)

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -291,6 +291,7 @@ if not no_shows_df.empty:
 else:
     st.sidebar.info("No no-shows found.")
 
+st.sidebar.subheader(f"Auto: {st.session_state.auto_day_change}, Button press: {st.session_state.button_pressed}")
 st.sidebar.toggle(
     label="Activate automatic day change", value=st.session_state.auto_day_change, on_change=toggle_auto_day_change
 )

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -292,12 +292,7 @@ else:
     st.sidebar.info("No no-shows found.")
 
 st.sidebar.subheader(f"Auto: {st.session_state.auto_day_change}, Button press: {st.session_state.button_pressed}")
-st.sidebar.toggle(
-    label="Activate automatic day change",
-    value=st.session_state.auto_day_change,
-    key="auto_day_change",
-    on_change=toggle_auto_day_change,
-)
+st.sidebar.toggle(label="Activate automatic day change", value=st.session_state.auto_day_change, key="auto_day_change")
 
 
 statistics_tab.subheader("Bed occupancy statistics")


### PR DESCRIPTION
zrobiłem tak, że jak się dzwoni to automatycznie zatrzymuje ten auto_day_change, dopiero jak się skończy rozmawiać ze wszystkimi pacjentami, to trzeba manualnie kliknąć, żeby wznowić auto_day_change