### PR TITLE
Fetch call transcryption

### DIFF
--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -152,3 +152,22 @@ def check_patient_consent_to_reschedule(conversation_id: str) -> bool:
     logger.info(f"Patient's verification status: {success_of_verification}")
     logger.info(f"Patient agreed: {result}")
     return {"consent": result, "verified": success_of_verification, "called": True}
+
+def fetch_transcryption(conversation_id: str):
+    max_attempts = 60
+
+    for attempt in range(max_attempts):
+        conversation_data = client.conversational_ai.get_conversation(conversation_id=conversation_id)
+        status = conversation_data.status
+        if status == "done":
+            result = json.loads(conversation_data.json())
+            with open("conversation_data.json", "w+") as f:
+                json.dump(result, f)
+                logger.info("Conversation data saved")
+            break
+        logger.info(f"Conversation status: {status} (Attempt {attempt + 1})")
+        time.sleep(5)
+    else:
+        logger.warning("Conversation did not complete in time.")
+        return False
+    

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -178,6 +178,6 @@ def fetch_transcription(conversation_id: str) -> list[dict]:
     transcript: list[dict] = json.loads(conversation_data.json()).get("transcript")
     # filter out transcript to have only roles and messages without empty messages or situations of using an agent tool such as 'end_call'
     transcript = [{"role": entry["role"], "message": entry["message"]} for entry in transcript]
-    transcript = list(filter(lambda data: data.message is not None, transcript))
+    transcript = list(filter(lambda data: data["message"] is not None, transcript))
 
     return transcript

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -138,7 +138,10 @@ def check_patient_consent_to_reschedule(conversation_id: str) -> dict:
     has given consent to reschedule their appointment.
 
     :param conversation_id: The ID of the conversation to analyze.
-    :return: A boolean indicating whether the patient agreed to reschedule.
+    :return: A dictionary containing:
+    - 'consent' (bool): Indicates whether the patient agreed to reschedule.
+    - 'verified' (bool): Indicates whether the verification was successful.
+    - 'called' (bool): Always True, indicating the function was executed.
     """
     conversation_data = get_done_conversation_data(conversation_id)
     result: bool = (

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -160,11 +160,16 @@ def fetch_transcription(conversation_id: str) -> list[dict]:
         conversation_data = client.conversational_ai.get_conversation(conversation_id=conversation_id)
         status = conversation_data.status
         if status == "done":
-            result = json.loads(conversation_data.json())
-            with open("conversation_data.json", "w+") as f:
-                json.dump(result, f)
-                logger.info("Conversation data saved")
-            break
+            # get transcript of the call
+            transcript: list[dict] = (
+                json.loads(conversation_data.json())
+                .get("transcript")
+            )
+            # filter out transcript to have only roles and messages without empty messages or situations of using an agent tool such as 'end_call'
+            transcript = [{"role": entry["role"], "message": entry["message"]} for entry in transcript]
+            transcript = list(filter(lambda data: data.message is not None, transcript))
+                
+            return transcript
         logger.info(f"Conversation status: {status} (Attempt {attempt + 1})")
         time.sleep(5)
     else:

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -112,10 +112,11 @@ def establish_voice_conversation(conversation: Conversation) -> str | None:
         conversation.end_session()
         return None
 
+
 def get_done_conversation_data(conversation_id: str, max_attempts: int = 60, attempt_interval: int = 5) -> str:
     """
     Waits until the conversation is completed and then returns its data in json format
-    
+
     :param conversation_id: The ID of the conversation to fetch the data.
     :param max_attempts: Maximum number of times the API is called in order to get data that has 'status' == 'done'
     :param attempt_interval: Seconds between API calls
@@ -131,6 +132,7 @@ def get_done_conversation_data(conversation_id: str, max_attempts: int = 60, att
     else:
         logger.warning("Conversation did not complete in time.")
         return False
+
 
 def check_patient_consent_to_reschedule(conversation_id: str) -> dict:
     """
@@ -162,23 +164,20 @@ def check_patient_consent_to_reschedule(conversation_id: str) -> dict:
     logger.info(f"Patient agreed: {result}")
     return {"consent": result, "verified": success_of_verification, "called": True}
 
+
 def fetch_transcription(conversation_id: str) -> list[dict]:
     """
-    Waits until the conversation is completed and then returns the transcript 
+    Waits until the conversation is completed and then returns the transcript
     of the given conversation.
-    
+
     :param conversation_id: The ID of the conversation to analyze.
     :return: List of python dictionaries that has 2 keys: "role" and "message"
     """
     conversation_data = get_done_conversation_data(conversation_id)
     # get transcript of the call
-    transcript: list[dict] = (
-        json.loads(conversation_data.json())
-        .get("transcript")
-    )
+    transcript: list[dict] = json.loads(conversation_data.json()).get("transcript")
     # filter out transcript to have only roles and messages without empty messages or situations of using an agent tool such as 'end_call'
     transcript = [{"role": entry["role"], "message": entry["message"]} for entry in transcript]
     transcript = list(filter(lambda data: data.message is not None, transcript))
-        
+
     return transcript
-    

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -132,7 +132,7 @@ def get_done_conversation_data(conversation_id: str, max_attempts: int = 60, att
         logger.warning("Conversation did not complete in time.")
         return False
 
-def check_patient_consent_to_reschedule(conversation_id: str) -> bool:
+def check_patient_consent_to_reschedule(conversation_id: str) -> dict:
     """
     Waits until the conversation is completed and then checks if the patient
     has given consent to reschedule their appointment.

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -153,7 +153,7 @@ def check_patient_consent_to_reschedule(conversation_id: str) -> bool:
     logger.info(f"Patient agreed: {result}")
     return {"consent": result, "verified": success_of_verification, "called": True}
 
-def fetch_transcryption(conversation_id: str):
+def fetch_transcription(conversation_id: str) -> list[dict]:
     max_attempts = 60
 
     for attempt in range(max_attempts):

--- a/frontend/locales/en/LC_MESSAGES/base.po
+++ b/frontend/locales/en/LC_MESSAGES/base.po
@@ -35,6 +35,9 @@ msgstr "Transcriptions"
 msgid "Bed Assignments"
 msgstr "Bed Assignments"
 
+msgid "No transcriptions avaiable, call patient in order to see transcriptions"
+msgstr "No transcriptions avaiable, call patient in order to see transcriptions"
+
 #: main.py:35
 msgid "Interface language"
 msgstr "Interface language"

--- a/frontend/locales/en/LC_MESSAGES/base.po
+++ b/frontend/locales/en/LC_MESSAGES/base.po
@@ -28,6 +28,9 @@ msgstr "Current state"
 msgid "Data analysis"
 msgstr "Data analysis"
 
+msgid "Transcriptions"
+msgstr "Transcriptions"
+
 #: main.py:32
 msgid "Bed Assignments"
 msgstr "Bed Assignments"

--- a/frontend/locales/pl/LC_MESSAGES/base.po
+++ b/frontend/locales/pl/LC_MESSAGES/base.po
@@ -29,6 +29,9 @@ msgstr "Stan obecny"
 msgid "Data analysis"
 msgstr "Analiza danych"
 
+msgid "Transcriptions"
+msgstr "Transkrypcje"
+
 #: main.py:32
 msgid "Bed Assignments"
 msgstr "Łóżka szpitalne"

--- a/frontend/locales/pl/LC_MESSAGES/base.po
+++ b/frontend/locales/pl/LC_MESSAGES/base.po
@@ -36,6 +36,9 @@ msgstr "Transkrypcje"
 msgid "Bed Assignments"
 msgstr "Łóżka szpitalne"
 
+msgid "No transcriptions avaiable, call patient in order to see transcriptions"
+msgstr "Nie ma jeszcze żadnych transkrypcji rozmów. Zadzwoń do pacjenta, aby zobaczyć transkrypcje"
+
 #: main.py:35
 msgid "Interface language"
 msgstr "Język interfejsu"

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -357,7 +357,7 @@ def agent_call(
             st.session_state.pop("current_patient_index", None)
     else:
         main_tab.info(f"{name} {surname}{_("'s consent is unknown.")}.")
-    
+
     if "transcript" in call_results and len(call_results["transcript"]) > 0:
         transcript_tab.empty()
         for message in call_results["transcript"]:

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -33,6 +33,7 @@ st.set_page_config(page_title=_("Hospital bed management"), page_icon="🏥")
 
 main_tab, statistics_tab, transcript_tab = st.tabs([_("Current state"), _("Data analysis"), _("Transcriptions")])
 main_tab.title(_("Bed Assignments"))
+transcript_tab.info(_("No transcriptions avaiable, call patient in order to see transcriptions"))
 
 ui_languages = ["en", "pl"]
 voice_languages = ["pl", "ua", _("nationality")]

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -362,11 +362,15 @@ def agent_call(
         main_tab.info(f"{name} {surname}{_("'s consent is unknown.")}.")
 
     if "transcript" in call_results and len(call_results["transcript"]) > 0:
+        st.session_state.transcriptions.append({"patient": f"{name} {surname}", "transcript": call_results["transcript"]})
+
         transcript_tab.empty()
-        expander = transcript_tab.expander(f"Call with {name} {surname}")
-        for message in call_results["transcript"]:
-            msg = expander.chat_message(message["role"] if message["role"] == "user" else "ai")
-            msg.write(message["message"])
+
+        for transcript in st.session_state.transcriptions:
+            expander = transcript_tab.expander(f"Call with {transcript['patient']}")
+            for message in transcript["transcript"]:
+                msg = expander.chat_message(message["role"] if message["role"] == "user" else "ai")
+                msg.write(message["message"])
 
 
 def call_next_patient_in_queue(

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -291,6 +291,7 @@ def handle_patient_rescheduling(
         conversation_id = call_patient(
             name, surname, gender, pesel, medical_procedure, old_day, new_day, use_ua_agent, str(st.session_state.phone_number)
         )
+        fetch_transcryption(conversation_id)
         return check_patient_consent_to_reschedule(conversation_id)
     else:
         return {"consent": None, "verified": None, "called": False}

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -291,7 +291,7 @@ def handle_patient_rescheduling(
         conversation_id = call_patient(
             name, surname, gender, pesel, medical_procedure, old_day, new_day, use_ua_agent, str(st.session_state.phone_number)
         )
-        fetch_transcryption(conversation_id)
+        fetch_transcription(conversation_id)
         return check_patient_consent_to_reschedule(conversation_id)
     else:
         return {"consent": None, "verified": None, "called": False}

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -284,7 +284,8 @@ def handle_patient_rescheduling(
     :param medical_procedure: The medical procedure that the patient will undergo.
     :param old_day: The current day of the patient's visit.
     :param new_day: The suggested day for the new appointment.
-    :return: A boolean indicating whether the patient consented to the rescheduling.
+    :return: A dictionary containing keys: "consent", "verified", "called" and "transcript". \n
+        "consent" is a boolean indicating whether the patient consented to the rescheduling.
     """
 
     if st.session_state.phone_number is not None:

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -31,7 +31,7 @@ _ = translate_page(st.session_state.interface_language)
 
 st.set_page_config(page_title=_("Hospital bed management"), page_icon="🏥")
 
-main_tab, statistics_tab = st.tabs([_("Current state"), _("Data analysis")])
+main_tab, statistics_tab, transcript_tab = st.tabs([_("Current state"), _("Data analysis"), _("Transcriptions")])
 main_tab.title(_("Bed Assignments"))
 
 ui_languages = ["en", "pl"]

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -357,6 +357,12 @@ def agent_call(
             st.session_state.pop("current_patient_index", None)
     else:
         main_tab.info(f"{name} {surname}{_("'s consent is unknown.")}.")
+    
+    if "transcript" in call_results and len(call_results["transcript"]) > 0:
+        transcript_tab.empty()
+        for message in call_results["transcript"]:
+            msg = transcript_tab.chat_message(message.role)
+            msg.write(message.message)
 
 
 def call_next_patient_in_queue(

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -53,6 +53,8 @@ if "consent" not in st.session_state:
     st.session_state.consent = False
 if "replacement_start_index" not in st.session_state:
     st.session_state.replacement_start_index = 0
+if "transcriptions" not in st.session_state:
+    st.session_state.transcriptions = []
 
 today = datetime.today().date()
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -33,7 +33,6 @@ st.set_page_config(page_title=_("Hospital bed management"), page_icon="🏥")
 
 main_tab, statistics_tab, transcript_tab = st.tabs([_("Current state"), _("Data analysis"), _("Transcriptions")])
 main_tab.title(_("Bed Assignments"))
-transcript_tab.info(_("No transcriptions avaiable, call patient in order to see transcriptions"))
 
 ui_languages = ["en", "pl"]
 voice_languages = ["pl", "ua", _("nationality")]
@@ -55,6 +54,7 @@ if "replacement_start_index" not in st.session_state:
     st.session_state.replacement_start_index = 0
 if "transcriptions" not in st.session_state:
     st.session_state.transcriptions = []
+    transcript_tab.info(_("No transcriptions avaiable, call patient in order to see transcriptions"))
 
 today = datetime.today().date()
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -292,8 +292,8 @@ def handle_patient_rescheduling(
         conversation_id = call_patient(
             name, surname, gender, pesel, medical_procedure, old_day, new_day, use_ua_agent, str(st.session_state.phone_number)
         )
-        fetch_transcription(conversation_id)
-        return check_patient_consent_to_reschedule(conversation_id)
+        transcript = fetch_transcription(conversation_id)
+        return {**check_patient_consent_to_reschedule(conversation_id), "transcript": transcript}
     else:
         return {"consent": None, "verified": None, "called": False}
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -361,8 +361,8 @@ def agent_call(
     if "transcript" in call_results and len(call_results["transcript"]) > 0:
         transcript_tab.empty()
         for message in call_results["transcript"]:
-            msg = transcript_tab.chat_message(message.role)
-            msg.write(message.message)
+            msg = transcript_tab.chat_message(message["role"])
+            msg.write(message["message"])
 
 
 def call_next_patient_in_queue(

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -272,7 +272,7 @@ def create_box_grid(df: pd.DataFrame, actions_required_number: int, boxes_per_ro
 
 def handle_patient_rescheduling(
     name: str, surname: str, gender: str, pesel: str, medical_procedure: str, old_day: int, new_day: int, use_ua_agent: bool
-) -> bool:
+) -> dict:
     """
     Handles the process of rescheduling a patient's appointment by initiating a voice conversation
     with the patient and analyzing their consent.

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -361,8 +361,9 @@ def agent_call(
 
     if "transcript" in call_results and len(call_results["transcript"]) > 0:
         transcript_tab.empty()
+        expander = transcript_tab.expander(f"Call with {name} {surname}")
         for message in call_results["transcript"]:
-            msg = transcript_tab.chat_message(message["role"] if message["role"] == "user" else "ai")
+            msg = expander.chat_message(message["role"] if message["role"] == "user" else "ai")
             msg.write(message["message"])
 
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -361,7 +361,7 @@ def agent_call(
     if "transcript" in call_results and len(call_results["transcript"]) > 0:
         transcript_tab.empty()
         for message in call_results["transcript"]:
-            msg = transcript_tab.chat_message(message["role"])
+            msg = transcript_tab.chat_message(message["role"] if message["role"] == "user" else "ai")
             msg.write(message["message"])
 
 


### PR DESCRIPTION
# Key changes
- in `frontend/agent.py` added a function that retrieves transcription from a given call based on conversation_id
- conversations may be displayed in frontend via the new tab called "transcriptions"

# Minor changes
- corrected some docstrings
- added session_state variable in `frontend/main.py`
- moved some that would duplicate, into a new function called `get_done_conversation_data()` in `frontend/agent.py`